### PR TITLE
Added Kazakh language

### DIFF
--- a/src/languages.php
+++ b/src/languages.php
@@ -52,6 +52,7 @@ Class Languages
 		'fr' => 'French',
 		'gl' => 'Galician',
 		'ka' => 'Georgian',
+		'kk' => 'Kazakh',
 		'de' => 'German',
 		'el' => 'Greek',
 		'gu' => 'Gujarati',


### PR DESCRIPTION
Google translate now supports Kazakh language.